### PR TITLE
Feature/#62/translation database

### DIFF
--- a/backend/src/main/java/com/pharmacy/Pharmacy_Manager/controller/ItemController.java
+++ b/backend/src/main/java/com/pharmacy/Pharmacy_Manager/controller/ItemController.java
@@ -2,7 +2,10 @@ package com.pharmacy.Pharmacy_Manager.controller;
 
 import com.pharmacy.Pharmacy_Manager.dto.ItemQueryDto;
 import com.pharmacy.Pharmacy_Manager.dto.ItemRequestDto;
+import com.pharmacy.Pharmacy_Manager.dto.ItemTranslationRequestDto;
 import com.pharmacy.Pharmacy_Manager.model.ItemEntity;
+import com.pharmacy.Pharmacy_Manager.model.ItemEntityTranslation;
+import com.pharmacy.Pharmacy_Manager.model.Language;
 import com.pharmacy.Pharmacy_Manager.service.ItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -50,11 +53,16 @@ public class ItemController {
                 .toList();
     }
 
-
-    @GetMapping("/{id}")
-    public ItemRequestDto getItem(@PathVariable UUID id) {
+    @GetMapping("/{id}/{language}")
+    public Object getItem(@PathVariable UUID id, @PathVariable Language language) {
         ItemEntity item = itemService.getById(id)
-                .orElseThrow();
-        return ItemRequestDto.from(item);
+                .orElseThrow(() -> new RuntimeException("Item not found with id " + id));
+        if(language==Language.en){
+            return ItemRequestDto.from(item);
+        }
+        else{
+            ItemEntityTranslation item_trans = itemService.getByIdAndLanguage(id, language).orElseThrow(() -> new RuntimeException("Item not found with id " + id));
+            return ItemTranslationRequestDto.from(item, item_trans);
+        }
     }
 }

--- a/backend/src/main/java/com/pharmacy/Pharmacy_Manager/controller/ItemController.java
+++ b/backend/src/main/java/com/pharmacy/Pharmacy_Manager/controller/ItemController.java
@@ -10,6 +10,7 @@ import com.pharmacy.Pharmacy_Manager.service.ItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 @CrossOrigin(origins = "http://localhost:5173")
@@ -64,5 +65,22 @@ public class ItemController {
             ItemEntityTranslation item_trans = itemService.getByIdAndLanguage(id, language).orElseThrow(() -> new RuntimeException("Item not found with id " + id));
             return ItemTranslationRequestDto.from(item, item_trans);
         }
+    }
+
+    @GetMapping("/{language}")
+    public List<Object> getAllItems(@PathVariable Language language){
+        try {
+            if (language == Language.en) {
+                return Collections.singletonList(itemService.getAll().stream()
+                        .map(ItemRequestDto::from)
+                        .toList());
+            } else {
+                return Collections.singletonList(itemService.getAllLanguage(language)
+                        .stream().map(t -> ItemTranslationRequestDto.from(t.getItem(), t)).toList());
+            }
+        }catch(Exception e){
+            throw e;
+        }
+
     }
 }

--- a/backend/src/main/java/com/pharmacy/Pharmacy_Manager/dto/ItemTranslationRequestDto.java
+++ b/backend/src/main/java/com/pharmacy/Pharmacy_Manager/dto/ItemTranslationRequestDto.java
@@ -1,0 +1,42 @@
+package com.pharmacy.Pharmacy_Manager.dto;
+
+import com.pharmacy.Pharmacy_Manager.model.ItemEntity;
+import com.pharmacy.Pharmacy_Manager.model.ItemEntityTranslation;
+import lombok.Builder;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Builder
+public record ItemTranslationRequestDto(
+        UUID id,
+        String name,
+        String description,
+        String category,
+        Double price,
+        String brand,
+        String imageUrl,
+        LocalDate manufacturingDate,
+        LocalDate expirationDate,
+        Boolean prescriptionRequired,
+        String sideEffects,
+        Integer soldCount,
+        Integer stockQuantity
+) {
+    public static ItemTranslationRequestDto from(ItemEntity i, ItemEntityTranslation j) {
+        return ItemTranslationRequestDto.builder()
+                .id(i.getId())
+                .name(i.getName())
+                .description(j.getDescription())
+                .category(j.getCategory())
+                .price(i.getPrice())
+                .brand(i.getBrand())
+                .imageUrl(i.getImageUrl())
+                .manufacturingDate(i.getManufacturingDate())
+                .expirationDate(i.getExpirationDate())
+                .prescriptionRequired(i.getPrescriptionRequired())
+                .sideEffects(j.getSideEffects())
+                .soldCount(i.getSoldCount())
+                .stockQuantity(i.getStockQuantity())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/pharmacy/Pharmacy_Manager/model/ItemEntity.java
+++ b/backend/src/main/java/com/pharmacy/Pharmacy_Manager/model/ItemEntity.java
@@ -1,16 +1,12 @@
 package com.pharmacy.Pharmacy_Manager.model;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import jakarta.persistence.Column;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 @Builder
@@ -61,4 +57,8 @@ public class ItemEntity {
 
     @Column(nullable = false)
     private Integer stockQuantity;
+
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
+    private List<ItemEntityTranslation> translations;
+
 }

--- a/backend/src/main/java/com/pharmacy/Pharmacy_Manager/model/ItemEntityTranslation.java
+++ b/backend/src/main/java/com/pharmacy/Pharmacy_Manager/model/ItemEntityTranslation.java
@@ -1,0 +1,39 @@
+package com.pharmacy.Pharmacy_Manager.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Builder
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Table(name = "items_translation")
+public class ItemEntityTranslation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false, unique = true)
+    private UUID id_translation;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id", nullable = false, referencedColumnName = "id")
+    private ItemEntity item;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private String category;
+
+    @Column(nullable = false)
+    private String sideEffects;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Language language;
+}

--- a/backend/src/main/java/com/pharmacy/Pharmacy_Manager/model/Language.java
+++ b/backend/src/main/java/com/pharmacy/Pharmacy_Manager/model/Language.java
@@ -1,0 +1,6 @@
+package com.pharmacy.Pharmacy_Manager.model;
+
+public enum Language {
+    en,
+    ro
+}

--- a/backend/src/main/java/com/pharmacy/Pharmacy_Manager/repository/ItemEntityTranslationRepository.java
+++ b/backend/src/main/java/com/pharmacy/Pharmacy_Manager/repository/ItemEntityTranslationRepository.java
@@ -1,0 +1,17 @@
+package com.pharmacy.Pharmacy_Manager.repository;
+
+import com.pharmacy.Pharmacy_Manager.model.ItemEntityTranslation;
+import com.pharmacy.Pharmacy_Manager.model.Language;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ItemEntityTranslationRepository extends JpaRepository<ItemEntityTranslation, UUID> {
+
+    List<ItemEntityTranslation> findByItemId(UUID itemId);
+
+    // Optionally, find one translation by item id and language
+    Optional<ItemEntityTranslation> findByItemIdAndLanguage(UUID itemId, Language language);
+}

--- a/backend/src/main/java/com/pharmacy/Pharmacy_Manager/repository/ItemEntityTranslationRepository.java
+++ b/backend/src/main/java/com/pharmacy/Pharmacy_Manager/repository/ItemEntityTranslationRepository.java
@@ -14,4 +14,6 @@ public interface ItemEntityTranslationRepository extends JpaRepository<ItemEntit
 
     // Optionally, find one translation by item id and language
     Optional<ItemEntityTranslation> findByItemIdAndLanguage(UUID itemId, Language language);
+
+    List<ItemEntityTranslation> findAllByLanguage(Language language);
 }

--- a/backend/src/main/java/com/pharmacy/Pharmacy_Manager/service/ItemService.java
+++ b/backend/src/main/java/com/pharmacy/Pharmacy_Manager/service/ItemService.java
@@ -60,6 +60,10 @@ public class ItemService {
 
     public Optional<ItemEntityTranslation> getByIdAndLanguage(UUID id, Language language){return translationRepository.findByItemIdAndLanguage(id, language);}
 
+    public List<ItemEntity> getAll(){return itemRepository.findAll();}
+
+    public List<ItemEntityTranslation> getAllLanguage(Language language){return translationRepository.findAllByLanguage(language);}
+
     public List<ItemEntity> searchFilterSort(
             String search,
             String category,

--- a/backend/src/main/java/com/pharmacy/Pharmacy_Manager/service/ItemService.java
+++ b/backend/src/main/java/com/pharmacy/Pharmacy_Manager/service/ItemService.java
@@ -1,5 +1,8 @@
 package com.pharmacy.Pharmacy_Manager.service;
 
+import com.pharmacy.Pharmacy_Manager.model.ItemEntityTranslation;
+import com.pharmacy.Pharmacy_Manager.model.Language;
+import com.pharmacy.Pharmacy_Manager.repository.ItemEntityTranslationRepository;
 import com.pharmacy.Pharmacy_Manager.repository.ItemRepository;
 import com.pharmacy.Pharmacy_Manager.model.ItemEntity;
 import jakarta.transaction.Transactional;
@@ -16,6 +19,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ItemService {
     private final ItemRepository itemRepository;
+    private final ItemEntityTranslationRepository translationRepository;
+
     @Transactional
     public UUID addItem(
                         String name,
@@ -52,6 +57,8 @@ public class ItemService {
     public Optional<ItemEntity> getById(UUID id) {
         return itemRepository.findById(id);
     }
+
+    public Optional<ItemEntityTranslation> getByIdAndLanguage(UUID id, Language language){return translationRepository.findByItemIdAndLanguage(id, language);}
 
     public List<ItemEntity> searchFilterSort(
             String search,

--- a/backend/src/main/resources/db/migration/V11__create_itemEntityTranslation_table.sql
+++ b/backend/src/main/resources/db/migration/V11__create_itemEntityTranslation_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE items_translation (
+id_translation UUID PRIMARY KEY,
+id UUID NOT NULL,
+description TEXT NOT NULL,
+category VARCHAR(255) NOT NULL,
+side_effects TEXT NOT NULL,
+language VARCHAR(255) NOT NULL,
+
+CONSTRAINT fk_item_translation
+    FOREIGN KEY (id) REFERENCES items(id)
+);

--- a/backend/src/main/resources/db/migration/V12__mockdata_itemEntityTranslation.sql
+++ b/backend/src/main/resources/db/migration/V12__mockdata_itemEntityTranslation.sql
@@ -1,0 +1,31 @@
+INSERT INTO items_translation (id_translation, id, description, category, side_effects, language)
+VALUES
+    (gen_random_uuid(), (SELECT id FROM items WHERE name='PainRelief 500'), 'Ameliorează eficient durerile de cap și musculare', 'Medicamente', 'Greață, amețeli', 'ro'),
+
+    (gen_random_uuid(), (SELECT id FROM items WHERE name='Vitamin C 1000'),  'Întărește sistemul imunitar și sănătatea generală', 'Suplimente', 'Disconfort gastric', 'ro'),
+
+    (gen_random_uuid(), (SELECT id FROM items WHERE name='AllergyStop'), 'Ameliorează simptomele alergiilor sezoniere', 'Medicamente', 'Somnolență', 'ro'),
+
+    (gen_random_uuid(), (SELECT id FROM items WHERE name='Omega 3 Fish Oil'),  'Sprijină sănătatea inimii și a creierului', 'Suplimente', 'Gust de pește', 'ro'),
+
+    (gen_random_uuid(), (SELECT id FROM items WHERE name='Cough Relief Syrup'), 'Calmează tusea și iritația gâtului', 'Medicamente', 'Somnolență, greață', 'ro'),
+
+    (gen_random_uuid(), (SELECT id FROM items WHERE name='SleepWell'),  'Îmbunătățește calitatea somnului', 'Suplimente', 'Ușoară durere de cap', 'ro'),
+
+    (gen_random_uuid(), (SELECT id FROM items WHERE name='Probiotic Max'),  'Sprijină sănătatea digestivă', 'Suplimente', 'Balonare', 'ro'),
+
+    (gen_random_uuid(), (SELECT id FROM items WHERE name='Antibiotic A-Z'),  'Antibiotic cu spectru larg', 'Medicamente', 'Diaree, greață', 'ro'),
+
+    (gen_random_uuid(), (SELECT id FROM items WHERE name='EnergyBoost'),  'Crește energia și concentrarea', 'Suplimente', 'Neliniște, insomnie', 'ro'),
+
+    (gen_random_uuid(), (SELECT id FROM items WHERE name='HeartCare'), 'Sprijină sănătatea cardiovasculară', 'Suplimente', 'Ușoară amețeală', 'ro'),
+
+    (gen_random_uuid(), (SELECT id FROM items WHERE name='AntiFungal Cream'),  'Tratează infecțiile fungice ale pielii', 'Medicamente', 'Iritații ale pielii', 'ro'),
+
+    (gen_random_uuid(), (SELECT id FROM items WHERE name='Vitamin D 1000'), 'Sprijină sănătatea oaselor și imunitatea', 'Suplimente', 'Oboseală', 'ro'),
+
+    (gen_random_uuid(), (SELECT id FROM items WHERE name='MuscleRelief Gel'), 'Calmează durerile musculare și articulare', 'Medicamente', 'Erupție cutanată', 'ro'),
+
+    (gen_random_uuid(), (SELECT id FROM items WHERE name='BrainBoost'), 'Îmbunătățește funcția cognitivă', 'Suplimente', 'Durere de cap', 'ro'),
+
+    (gen_random_uuid(), (SELECT id FROM items WHERE name='ColdEase'), 'Reduce simptomele răcelii', 'Medicamente', 'Somnolență', 'ro');

--- a/frontend/src/pages/ItemPage/ItemPage.jsx
+++ b/frontend/src/pages/ItemPage/ItemPage.jsx
@@ -41,7 +41,7 @@ export default function ItemPage() {
     useEffect(() => {
         const load = async () => {
             try {
-                const r = await fetch(`${API_BASE}/items/${id}`);
+                const r = await fetch(`${API_BASE}/items/${id}/${i18n.language}`);
                 if (!r.ok) throw new Error(`HTTP ${r.status}`);
                 const data = await r.json();
                 setItem({ ...data, stock: 0 });//setItem(data)-in stock ;setItem({ ...data, stock: 0 })-out of stock


### PR DESCRIPTION
Created the translation for the database through another table(item_translation). The relationship between item table and item_translation table is one to many.

Changed the function in item controller so that it returns an item or the whole list of items with the specified translation:
example one element: http://localhost:8080/api/items/{id} -------> http://localhost:8080/api/items/{id}/{language}
example whole list: http://localhost:8080/api/items/{language}